### PR TITLE
fix(metrics): Add per-emitter throughput and remove dead code

### DIFF
--- a/gateway/src/hub.rs
+++ b/gateway/src/hub.rs
@@ -601,14 +601,12 @@ impl HubRunner {
 
             // Record per-emitter metrics
             if let Some(metrics) = Metrics::get() {
-                metrics.record_batch_size(emitter.name(), routed_events.len());
-                metrics.record_flush_duration(emitter.name(), emitter_duration.as_secs_f64());
-                metrics.set_emitter_health(emitter.name(), emit_result.is_ok());
-                // Per-emitter throughput: more accurate than global when emitters have different latencies
-                if emitter_duration.as_secs_f64() > 0.0 {
-                    let emitter_eps = routed_events.len() as f64 / emitter_duration.as_secs_f64();
-                    metrics.set_emitter_throughput(emitter.name(), emitter_eps);
-                }
+                metrics.record_emitter_flush(
+                    emitter.name(),
+                    routed_events.len(),
+                    emitter_duration,
+                    emit_result.is_ok(),
+                );
             }
 
             if let Err(e) = emit_result {
@@ -826,14 +824,12 @@ async fn flush_loop(
 
             // Record per-emitter metrics
             if let Some(metrics) = Metrics::get() {
-                metrics.record_batch_size(emitter.name(), routed_events.len());
-                metrics.record_flush_duration(emitter.name(), emitter_duration.as_secs_f64());
-                metrics.set_emitter_health(emitter.name(), emit_result.is_ok());
-                // Per-emitter throughput: more accurate than global when emitters have different latencies
-                if emitter_duration.as_secs_f64() > 0.0 {
-                    let emitter_eps = routed_events.len() as f64 / emitter_duration.as_secs_f64();
-                    metrics.set_emitter_throughput(emitter.name(), emitter_eps);
-                }
+                metrics.record_emitter_flush(
+                    emitter.name(),
+                    routed_events.len(),
+                    emitter_duration,
+                    emit_result.is_ok(),
+                );
             }
 
             if let Err(e) = emit_result {


### PR DESCRIPTION
## Summary

- Add `polku_emitter_throughput` gauge metric for accurate per-emitter throughput tracking (events/sec)
- Remove unused `record_forwarded()` method - only batch version remains
- Update both flush paths to calculate and record per-emitter throughput

## Why

Per-emitter throughput is more accurate when emitters have different latencies. The previous global `events_per_second` calculated `total_events / total_flush_duration`, which was misleading with multiple emitters of varying latency.

## Test plan

- [x] Added `test_per_emitter_throughput` test
- [x] Added `test_no_per_event_record_forwarded` test  
- [x] All 208 tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)