### PR TITLE
chore: release readiness — align thiserror, add MSRV, add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-02-12
+
+Initial pre-release of POLKU as an open-source programmable protocol hub.
+
+### Added
+
+- **Message-first pipeline**: `Message` is the sole type flowing through the pipeline. No more `Event<->Message` conversions on the hot path (#46)
+- **AI-native introspection**: Pipeline manifest (`/pipeline`), per-message processing trace (`polku.trace`), structured error context with `ErrorContext` + `PipelineStage` (#46)
+- **Pipeline health endpoint**: `/health` returns structured JSON with pipeline pressure metric (0.0-1.0), K8s liveness/readiness compatible (#46)
+- **Middleware suite**: Router, RateLimiter, Deduplicator, Sampler, Throttle, Enricher, Validator, Aggregator
+- **Resilience patterns**: RetryEmitter (exponential backoff + jitter), CircuitBreakerEmitter, FailureCaptureEmitter
+- **GrpcEmitter**: Least-loaded endpoint selection, automatic failover, per-endpoint health tracking
+- **TieredBuffer**: Primary ring buffer with zstd-compressed secondary tier for overflow
+- **LockFreeBuffer**: Crossbeam-backed buffer for high-throughput scenarios
+- **Per-middleware Prometheus metrics**: `polku_middleware_duration_seconds`, `polku_middleware_messages_total` (#53)
+- **Bidirectional streaming**: High-throughput gRPC streaming for ingestors and emitters (#31)
+- **External plugin system**: gRPC-based ingestor and emitter plugins with discovery service
+- **Batch compression**: TieredBuffer secondary tier uses zstd compression (#26)
+- **40+ Prometheus metrics**: Events, throughput, buffer, emitter health, circuit breaker, pipeline pressure
+- **Example plugins**: Python Slack emitter, Go CSV ingestor
+
+### Fixed
+
+- AHTI emitter: 5 conversion bugs (timestamp nanos, severity mapping, entity extraction, duration precedence, empty-field handling) (#49)
+- Preserve original event IDs through pipeline instead of generating new ULIDs (#30)
+- Extracted shared `emit_to_destinations` to eliminate ~90 lines of duplicated flush logic (#53)
+- Shared `TokenBucket` implementation replacing 3 independent copies (#51)
+- Shared endpoint health tracking replacing duplicated health logic (#52)
+
+### Architecture
+
+- `polku-core`: Emitter trait, Message, PluginError, Event proto, metadata key constants
+- `polku-gateway`: Hub, Ingestors, Middleware, Emitters, Buffer strategies
+- Zero-copy `Bytes` payloads flow end-to-end (no `.to_vec()` on hot path)
+- `InternedStr` for source/message_type fields (O(1) comparison, deduped storage)
+
+### Infrastructure
+
+- Multi-stage Dockerfile (non-root, stripped release binary)
+- SYKLI CI integration (fmt, clippy, test, build)
+- E2E black-box test infrastructure with Kind cluster support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = ["core", "gateway", "ci", "test-plugins/receiver"]
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Yair Etziony <yair.etziony@false-systems.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/falsesystems/polku"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming"]
 async-trait = "0.1"
 
 # Error handling
-thiserror = "1.0"
+thiserror = "2"
 
 # Proto/gRPC (only what we need for Event type)
 prost = "0.13"


### PR DESCRIPTION
## Summary

- Align `thiserror` version across workspace: polku-core `"1.0"` → `"2"` (matches gateway, eliminates mixed `Error` trait impls at crate boundary)
- Add `rust-version = "1.85"` to workspace metadata so consumers know the MSRV
- Create `CHANGELOG.md` with full 0.1.0 release notes

Driven by a 6-agent release readiness audit that flagged these as must-fix items before release.

## Test plan

- [x] `cargo test --all` — 471 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes needed
- [x] thiserror 2 derive is identical syntax to 1.x — seamless upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)