### PR TITLE
feat: add polku-fp crate — FALSE Protocol plugins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "gateway", "runtime", "ci", "test-plugins/receiver"]
+members = ["core", "gateway", "runtime", "fp", "ci", "test-plugins/receiver"]
 exclude = ["tests/e2e"]
 
 [workspace.package]

--- a/fp/Cargo.toml
+++ b/fp/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "polku-fp"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "FALSE Protocol plugins for POLKU — Occurrence ingestor, router, and probe"
+keywords = ["false-protocol", "event", "gateway", "observability"]
+categories = ["network-programming"]
+
+[lints]
+workspace = true
+
+[dependencies]
+# Core types (Message, MessageId, Emitter, PluginError)
+polku-core = { path = "../core" }
+
+# Gateway types (Ingestor, Middleware, Metrics)
+polku-gateway = { path = "../gateway" }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Zero-copy buffers
+bytes = "1"
+
+# Async
+async-trait = "0.1"
+tokio = { version = "1", features = ["time"] }
+
+# Observability
+tracing = "0.1"
+prometheus = "0.13"
+
+# IDs and timestamps
+ulid = "1"
+chrono = "0.4"
+
+# Inline small collections (Routes)
+smallvec = "1.13"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros", "time", "test-util"] }

--- a/fp/src/ingest.rs
+++ b/fp/src/ingest.rs
@@ -1,0 +1,253 @@
+//! OccurrenceIngestor — decode FALSE Protocol Occurrences into Messages
+//!
+//! Parses Occurrence JSON (single or array), maps fields to Message,
+//! and preserves the full JSON in `msg.payload` for downstream consumers.
+
+use crate::occurrence::Occurrence;
+use bytes::Bytes;
+use polku_core::message::MessageId;
+use polku_core::metadata_keys;
+use polku_gateway::PluginError;
+use polku_gateway::ingest::{IngestContext, Ingestor};
+use polku_gateway::message::Message;
+
+/// Ingestor for FALSE Protocol Occurrences
+///
+/// Accepts Occurrence JSON in two formats:
+/// - Single object: `{"id": "...", "type": "ci.test.failed", ...}`
+/// - Array: `[{...}, {...}]`
+///
+/// # Field Mapping
+///
+/// | Occurrence field | Message field |
+/// |-----------------|---------------|
+/// | `id` | `msg.id` (ULID) |
+/// | `timestamp` | `msg.timestamp` (parsed to unix nanos) |
+/// | `source` | `msg.source` |
+/// | `type` | `msg.message_type` |
+/// | `severity` | `metadata["polku.severity"]` |
+/// | `outcome` | `metadata["polku.outcome"]` |
+/// | Full JSON | `msg.payload` (zero-copy passthrough) |
+pub struct OccurrenceIngestor;
+
+impl OccurrenceIngestor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for OccurrenceIngestor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OccurrenceIngestor {
+    fn occurrence_to_message(&self, occ: Occurrence, raw_json: Bytes) -> Message {
+        let id = MessageId::from_string(&occ.id);
+
+        let timestamp = chrono::DateTime::parse_from_rfc3339(&occ.timestamp)
+            .map(|dt| dt.timestamp_nanos_opt().unwrap_or(0))
+            .unwrap_or_else(|_| chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0));
+
+        let mut msg = Message {
+            id,
+            timestamp,
+            source: occ.source.into(),
+            message_type: occ.occurrence_type.into(),
+            metadata: None,
+            payload: raw_json,
+            route_to: smallvec::SmallVec::new(),
+        };
+
+        // Map severity and outcome to metadata
+        msg.metadata_mut().insert(
+            metadata_keys::SEVERITY.to_string(),
+            occ.severity.as_polku_value().to_string(),
+        );
+        msg.metadata_mut().insert(
+            metadata_keys::OUTCOME.to_string(),
+            occ.outcome.as_polku_value().to_string(),
+        );
+        msg.metadata_mut().insert(
+            metadata_keys::CONTENT_TYPE.to_string(),
+            "application/json".to_string(),
+        );
+
+        msg
+    }
+}
+
+impl Ingestor for OccurrenceIngestor {
+    fn name(&self) -> &str {
+        "occurrence"
+    }
+
+    fn sources(&self) -> &[&str] {
+        &["occurrence", "false-protocol"]
+    }
+
+    fn ingest(&self, _ctx: &IngestContext, data: &[u8]) -> Result<Vec<Message>, PluginError> {
+        let text = std::str::from_utf8(data)
+            .map_err(|e| PluginError::Transform(format!("Invalid UTF-8: {e}")))?;
+
+        let trimmed = text.trim();
+
+        if trimmed.starts_with('[') {
+            // Array of Occurrences — parse each, preserve individual JSON
+            let occurrences: Vec<serde_json::Value> = serde_json::from_str(trimmed)
+                .map_err(|e| PluginError::Transform(format!("Invalid JSON array: {e}")))?;
+
+            let mut messages = Vec::with_capacity(occurrences.len());
+            for val in occurrences {
+                let raw = serde_json::to_vec(&val)
+                    .map_err(|e| PluginError::Transform(format!("JSON re-serialization: {e}")))?;
+                let occ: Occurrence = serde_json::from_value(val)
+                    .map_err(|e| PluginError::Transform(format!("Invalid Occurrence: {e}")))?;
+                messages.push(self.occurrence_to_message(occ, Bytes::from(raw)));
+            }
+            Ok(messages)
+        } else {
+            // Single Occurrence — use input bytes as payload (zero-copy)
+            let occ: Occurrence = serde_json::from_str(trimmed)
+                .map_err(|e| PluginError::Transform(format!("Invalid Occurrence JSON: {e}")))?;
+            let payload = Bytes::copy_from_slice(data);
+            Ok(vec![self.occurrence_to_message(occ, payload)])
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> IngestContext<'static> {
+        IngestContext {
+            source: "occurrence",
+            cluster: "prod",
+            format: "json",
+        }
+    }
+
+    #[test]
+    fn test_valid_occurrence_maps_fields() {
+        let ingestor = OccurrenceIngestor::new();
+        let json = r#"{
+            "id": "01HWXYZ",
+            "timestamp": "2024-01-15T10:30:00Z",
+            "source": "sykli",
+            "type": "ci.test.failed",
+            "severity": "error",
+            "outcome": "failure"
+        }"#;
+
+        let msgs = ingestor.ingest(&ctx(), json.as_bytes()).unwrap();
+        assert_eq!(msgs.len(), 1);
+
+        let msg = &msgs[0];
+        assert_eq!(msg.id, "01HWXYZ");
+        assert_eq!(msg.source, "sykli");
+        assert_eq!(msg.message_type, "ci.test.failed");
+        assert_eq!(
+            msg.metadata().get(metadata_keys::SEVERITY),
+            Some(&"4".to_string())
+        );
+        assert_eq!(
+            msg.metadata().get(metadata_keys::OUTCOME),
+            Some(&"2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_occurrence_with_error_block() {
+        let ingestor = OccurrenceIngestor::new();
+        let json = r#"{
+            "id": "01ERR",
+            "timestamp": "2024-01-15T10:30:00Z",
+            "source": "sykli",
+            "type": "ci.build.failed",
+            "severity": "critical",
+            "outcome": "failure",
+            "error": {
+                "code": "BUILD_FAILURE",
+                "what_failed": "Cargo build failed"
+            }
+        }"#;
+
+        let msgs = ingestor.ingest(&ctx(), json.as_bytes()).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(
+            msgs[0].metadata().get(metadata_keys::SEVERITY),
+            Some(&"5".to_string())
+        );
+    }
+
+    #[test]
+    fn test_invalid_json_returns_error() {
+        let ingestor = OccurrenceIngestor::new();
+        let result = ingestor.ingest(&ctx(), b"not valid json");
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            PluginError::Transform(_) => {}
+            other => panic!("Expected Transform error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_array_of_occurrences() {
+        let ingestor = OccurrenceIngestor::new();
+        let json = r#"[
+            {"id": "01A", "timestamp": "2024-01-15T10:30:00Z", "source": "sykli", "type": "ci.test.passed", "severity": "info", "outcome": "success"},
+            {"id": "01B", "timestamp": "2024-01-15T10:31:00Z", "source": "tapio", "type": "kernel.syscall.blocked", "severity": "warning", "outcome": "unknown"}
+        ]"#;
+
+        let msgs = ingestor.ingest(&ctx(), json.as_bytes()).unwrap();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].source, "sykli");
+        assert_eq!(msgs[0].message_type, "ci.test.passed");
+        assert_eq!(msgs[1].source, "tapio");
+        assert_eq!(msgs[1].message_type, "kernel.syscall.blocked");
+    }
+
+    #[test]
+    fn test_minimal_occurrence_no_crash() {
+        let ingestor = OccurrenceIngestor::new();
+        let json = r#"{
+            "id": "01MIN",
+            "timestamp": "2024-01-15T10:30:00Z",
+            "source": "test",
+            "type": "test.event",
+            "severity": "debug",
+            "outcome": "unknown"
+        }"#;
+
+        let msgs = ingestor.ingest(&ctx(), json.as_bytes()).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message_type, "test.event");
+    }
+
+    #[test]
+    fn test_full_json_preserved_in_payload() {
+        let ingestor = OccurrenceIngestor::new();
+        let json = r#"{"id":"01P","timestamp":"2024-01-15T10:30:00Z","source":"s","type":"t","severity":"info","outcome":"success","data":{"key":"value"}}"#;
+
+        let msgs = ingestor.ingest(&ctx(), json.as_bytes()).unwrap();
+        // Payload should contain the full JSON
+        let payload_str = msgs[0].payload_str().unwrap();
+        assert!(payload_str.contains("\"data\""));
+        assert!(payload_str.contains("\"key\":\"value\""));
+    }
+
+    #[test]
+    fn test_content_type_metadata_set() {
+        let ingestor = OccurrenceIngestor::new();
+        let json = r#"{"id":"01CT","timestamp":"2024-01-15T10:30:00Z","source":"s","type":"t","severity":"info","outcome":"success"}"#;
+
+        let msgs = ingestor.ingest(&ctx(), json.as_bytes()).unwrap();
+        assert_eq!(
+            msgs[0].metadata().get(metadata_keys::CONTENT_TYPE),
+            Some(&"application/json".to_string())
+        );
+    }
+}

--- a/fp/src/lib.rs
+++ b/fp/src/lib.rs
@@ -1,0 +1,45 @@
+//! polku-fp — FALSE Protocol plugins for POLKU
+//!
+//! Three capabilities, all optional:
+//!
+//! - **Transport**: `OccurrenceIngestor` + `OccurrenceRouter` — decode and route Occurrences
+//! - **Self-Aware**: `Probe` — observe the pipeline and emit Occurrences about it
+//! - **Clean**: Don't import this crate — default POLKU behavior
+//!
+//! # Transport Mode
+//!
+//! ```ignore
+//! use polku_fp::{OccurrenceIngestor, OccurrenceRouter};
+//!
+//! polku_runtime::run(|hub| async move {
+//!     Ok(hub
+//!         .ingestor(OccurrenceIngestor::new())
+//!         .middleware(OccurrenceRouter::new()
+//!             .route("ci.", "sykli")
+//!             .route("kernel.", "tapio"))
+//!         .emitter(grpc_sykli)
+//!         .emitter(grpc_tapio))
+//! }).await
+//! ```
+//!
+//! # Self-Aware Mode
+//!
+//! ```ignore
+//! use polku_fp::Probe;
+//!
+//! let probe = Probe::new("polku-prod")
+//!     .pressure_threshold(0.8)
+//!     .tick_secs(5)
+//!     .emitter(ahti_emitter);
+//! tokio::spawn(probe.run());
+//! ```
+
+pub mod ingest;
+pub mod middleware;
+pub mod occurrence;
+pub mod probe;
+
+pub use ingest::OccurrenceIngestor;
+pub use middleware::OccurrenceRouter;
+pub use occurrence::{Context, Entity, Error, Occurrence, Outcome, Reasoning, Severity};
+pub use probe::Probe;

--- a/fp/src/middleware.rs
+++ b/fp/src/middleware.rs
@@ -1,0 +1,138 @@
+//! OccurrenceRouter — route Messages by Occurrence type prefix
+//!
+//! A convenience middleware for routing FALSE Protocol Occurrences.
+//! Uses prefix matching on `msg.message_type` (set by `OccurrenceIngestor`).
+
+use async_trait::async_trait;
+use polku_gateway::message::Message;
+use polku_gateway::middleware::Middleware;
+
+/// Routes messages by Occurrence type prefix
+///
+/// Builder-style API for declaring routing rules. First match wins.
+/// If no rules match, the message passes through unchanged.
+///
+/// # Example
+///
+/// ```ignore
+/// let router = OccurrenceRouter::new()
+///     .route("ci.", "sykli")
+///     .route("kernel.", "tapio")
+///     .route("correlation.", "ahti");
+/// ```
+pub struct OccurrenceRouter {
+    rules: Vec<(String, Vec<String>)>,
+}
+
+impl OccurrenceRouter {
+    pub fn new() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    /// Add a routing rule: messages whose `message_type` starts with `prefix`
+    /// are routed to `target`.
+    pub fn route(mut self, prefix: &str, target: &str) -> Self {
+        // Check if we already have a rule for this prefix to allow multi-target
+        if let Some(existing) = self.rules.iter_mut().find(|(p, _)| p == prefix) {
+            existing.1.push(target.to_string());
+        } else {
+            self.rules
+                .push((prefix.to_string(), vec![target.to_string()]));
+        }
+        self
+    }
+}
+
+impl Default for OccurrenceRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Middleware for OccurrenceRouter {
+    fn name(&self) -> &str {
+        "occurrence-router"
+    }
+
+    async fn process(&self, mut msg: Message) -> Option<Message> {
+        for (prefix, targets) in &self.rules {
+            if msg.message_type.starts_with(prefix) {
+                msg.route_to = smallvec::SmallVec::from_vec(targets.clone());
+                tracing::debug!(
+                    id = %msg.id,
+                    message_type = %msg.message_type,
+                    routes = ?msg.route_to,
+                    "occurrence routed"
+                );
+                return Some(msg);
+            }
+        }
+        // No match — pass through unchanged
+        Some(msg)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    #[tokio::test]
+    async fn test_route_ci_to_sykli() {
+        let router = OccurrenceRouter::new().route("ci.", "sykli");
+
+        let msg = Message::new("sykli", "ci.test.failed", Bytes::new());
+        let result = router.process(msg).await.unwrap();
+        assert_eq!(result.route_to.as_slice(), &["sykli".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_route_kernel_to_tapio() {
+        let router = OccurrenceRouter::new()
+            .route("ci.", "sykli")
+            .route("kernel.", "tapio");
+
+        let msg = Message::new("tapio", "kernel.syscall.blocked", Bytes::new());
+        let result = router.process(msg).await.unwrap();
+        assert_eq!(result.route_to.as_slice(), &["tapio".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_no_match_passes_through() {
+        let router = OccurrenceRouter::new()
+            .route("ci.", "sykli")
+            .route("kernel.", "tapio");
+
+        let msg = Message::new("unknown", "billing.invoice.created", Bytes::new());
+        let result = router.process(msg).await.unwrap();
+        assert!(result.route_to.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_first_match_wins() {
+        let router = OccurrenceRouter::new()
+            .route("ci.", "first")
+            .route("ci.test.", "second");
+
+        let msg = Message::new("sykli", "ci.test.failed", Bytes::new());
+        let result = router.process(msg).await.unwrap();
+        // "ci." matches before "ci.test."
+        assert_eq!(result.route_to.as_slice(), &["first".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_multi_target_same_prefix() {
+        let router = OccurrenceRouter::new()
+            .route("ci.", "sykli")
+            .route("ci.", "ahti");
+
+        let msg = Message::new("sykli", "ci.test.failed", Bytes::new());
+        let result = router.process(msg).await.unwrap();
+        assert_eq!(
+            result.route_to.as_slice(),
+            &["sykli".to_string(), "ahti".to_string()]
+        );
+    }
+}

--- a/fp/src/occurrence.rs
+++ b/fp/src/occurrence.rs
@@ -1,0 +1,297 @@
+//! Minimal FALSE Protocol types for POLKU ingestion and probe output
+//!
+//! These are local types matching the FALSE Protocol JSON schema.
+//! Replace with the `false-protocol` crate when published.
+
+use serde::{Deserialize, Serialize};
+
+/// A FALSE Protocol Occurrence — the atomic unit of observable truth
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Occurrence {
+    /// ULID identifier
+    pub id: String,
+
+    /// ISO 8601 timestamp
+    pub timestamp: String,
+
+    /// Origin system (e.g., "sykli", "tapio")
+    pub source: String,
+
+    /// Hierarchical type (e.g., "ci.test.failed", "kernel.syscall.blocked")
+    #[serde(rename = "type")]
+    pub occurrence_type: String,
+
+    /// Severity level
+    pub severity: Severity,
+
+    /// Outcome of the observed event
+    pub outcome: Outcome,
+
+    /// Contextual information
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<Context>,
+
+    /// Error details (when severity >= Warning)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<Error>,
+
+    /// AI reasoning about the occurrence
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<Reasoning>,
+
+    /// Arbitrary structured data
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// Severity levels matching FALSE Protocol spec
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Critical,
+}
+
+impl Severity {
+    /// Map to polku.severity metadata value (i32 string)
+    pub fn as_polku_value(&self) -> &'static str {
+        match self {
+            Self::Debug => "1",
+            Self::Info => "2",
+            Self::Warning => "3",
+            Self::Error => "4",
+            Self::Critical => "5",
+        }
+    }
+}
+
+/// Outcome of an observed event
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Outcome {
+    Success,
+    Failure,
+    Timeout,
+    InProgress,
+    Unknown,
+}
+
+impl Outcome {
+    /// Map to polku.outcome metadata value (i32 string)
+    pub fn as_polku_value(&self) -> &'static str {
+        match self {
+            Self::Success => "1",
+            Self::Failure => "2",
+            Self::Timeout => "3",
+            Self::InProgress => "4",
+            Self::Unknown => "0",
+        }
+    }
+}
+
+/// Contextual information about where the occurrence happened
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Context {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cluster: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub correlation_keys: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entities: Vec<Entity>,
+}
+
+/// Error block — what went wrong and why it matters
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Error {
+    /// Machine-readable error code (e.g., "TEST_FAILURE", "SYSCALL_DENIED")
+    pub code: String,
+
+    /// Human-readable description of what failed
+    pub what_failed: String,
+
+    /// Why this failure matters
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub why_it_matters: Option<String>,
+
+    /// Possible root causes
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub possible_causes: Vec<String>,
+
+    /// Recommended fix
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_fix: Option<String>,
+}
+
+/// AI reasoning about the occurrence
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Reasoning {
+    /// One-line summary
+    pub summary: String,
+
+    /// Detailed explanation
+    pub explanation: String,
+
+    /// Confidence score (0.0 - 1.0)
+    pub confidence: f64,
+
+    /// Chain of causal reasoning
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub causal_chain: Vec<String>,
+
+    /// Patterns that matched to produce this reasoning
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub patterns_matched: Vec<String>,
+}
+
+/// An observed entity (service, pod, node, etc.)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entity {
+    /// Entity type (e.g., "service", "pod", "node")
+    #[serde(rename = "type")]
+    pub entity_type: String,
+
+    /// Unique identifier
+    pub id: String,
+
+    /// Human-readable name
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Version string
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// When this entity was observed
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<String>,
+
+    /// Whether this entity is the source of truth
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_of_truth: Option<bool>,
+
+    /// Namespace / scope
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_occurrence_serialization_roundtrip() {
+        let occ = Occurrence {
+            id: "01HWXYZ".into(),
+            timestamp: "2024-01-15T10:30:00Z".into(),
+            source: "sykli".into(),
+            occurrence_type: "ci.test.failed".into(),
+            severity: Severity::Error,
+            outcome: Outcome::Failure,
+            context: Some(Context {
+                cluster: Some("prod".into()),
+                namespace: None,
+                correlation_keys: vec!["build-123".into()],
+                entities: vec![],
+            }),
+            error: Some(Error {
+                code: "TEST_FAILURE".into(),
+                what_failed: "Unit tests in auth module".into(),
+                why_it_matters: Some("Blocks release pipeline".into()),
+                possible_causes: vec!["Timeout in network mock".into()],
+                suggested_fix: Some("Increase mock timeout".into()),
+            }),
+            reasoning: None,
+            data: None,
+        };
+
+        let json = serde_json::to_string(&occ).unwrap();
+        let parsed: Occurrence = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.id, "01HWXYZ");
+        assert_eq!(parsed.occurrence_type, "ci.test.failed");
+        assert_eq!(parsed.severity, Severity::Error);
+        assert_eq!(parsed.outcome, Outcome::Failure);
+        assert_eq!(parsed.error.unwrap().code, "TEST_FAILURE");
+    }
+
+    #[test]
+    fn test_minimal_occurrence() {
+        let json = r#"{
+            "id": "01ABC",
+            "timestamp": "2024-01-15T10:30:00Z",
+            "source": "tapio",
+            "type": "kernel.syscall.blocked",
+            "severity": "warning",
+            "outcome": "unknown"
+        }"#;
+
+        let occ: Occurrence = serde_json::from_str(json).unwrap();
+        assert_eq!(occ.source, "tapio");
+        assert_eq!(occ.occurrence_type, "kernel.syscall.blocked");
+        assert!(occ.context.is_none());
+        assert!(occ.error.is_none());
+        assert!(occ.reasoning.is_none());
+        assert!(occ.data.is_none());
+    }
+
+    #[test]
+    fn test_severity_polku_mapping() {
+        assert_eq!(Severity::Debug.as_polku_value(), "1");
+        assert_eq!(Severity::Info.as_polku_value(), "2");
+        assert_eq!(Severity::Warning.as_polku_value(), "3");
+        assert_eq!(Severity::Error.as_polku_value(), "4");
+        assert_eq!(Severity::Critical.as_polku_value(), "5");
+    }
+
+    #[test]
+    fn test_outcome_polku_mapping() {
+        assert_eq!(Outcome::Success.as_polku_value(), "1");
+        assert_eq!(Outcome::Failure.as_polku_value(), "2");
+        assert_eq!(Outcome::Timeout.as_polku_value(), "3");
+        assert_eq!(Outcome::InProgress.as_polku_value(), "4");
+        assert_eq!(Outcome::Unknown.as_polku_value(), "0");
+    }
+
+    #[test]
+    fn test_type_field_renamed() {
+        let json = r#"{"id":"x","timestamp":"t","source":"s","type":"ci.test.failed","severity":"info","outcome":"success"}"#;
+        let occ: Occurrence = serde_json::from_str(json).unwrap();
+        assert_eq!(occ.occurrence_type, "ci.test.failed");
+
+        // Serialized back should use "type" not "occurrence_type"
+        let serialized = serde_json::to_string(&occ).unwrap();
+        assert!(serialized.contains(r#""type":"ci.test.failed""#));
+        assert!(!serialized.contains("occurrence_type"));
+    }
+
+    #[test]
+    fn test_optional_fields_skipped_in_serialization() {
+        let occ = Occurrence {
+            id: "x".into(),
+            timestamp: "t".into(),
+            source: "s".into(),
+            occurrence_type: "test".into(),
+            severity: Severity::Info,
+            outcome: Outcome::Success,
+            context: None,
+            error: None,
+            reasoning: None,
+            data: None,
+        };
+
+        let json = serde_json::to_string(&occ).unwrap();
+        assert!(!json.contains("context"));
+        assert!(!json.contains("error"));
+        assert!(!json.contains("reasoning"));
+        assert!(!json.contains("data"));
+    }
+}

--- a/fp/src/probe.rs
+++ b/fp/src/probe.rs
@@ -1,0 +1,753 @@
+//! Probe — self-aware pipeline observer
+//!
+//! A standalone async task that watches the pipeline via a [`MetricsSource`],
+//! detects state transitions, and emits FALSE Protocol Occurrences about what it sees.
+//!
+//! The Probe is NOT part of the message pipeline — it's a side-channel observer
+//! with its own Emitter. This avoids feedback loops.
+
+use crate::occurrence::{Error, Occurrence, Outcome, Reasoning, Severity};
+use bytes::Bytes;
+use polku_core::Emitter;
+use polku_gateway::message::Message;
+use polku_gateway::metrics::Metrics;
+use std::sync::Arc;
+use tokio::time::{Duration, interval};
+
+/// Point-in-time reading of the 5 values the Probe cares about
+pub struct MetricsSnapshot {
+    pub pipeline_pressure: f64,
+    pub buffer_overflow_total: f64,
+    pub emitter_healthy: usize,
+    pub emitter_unhealthy: usize,
+    pub any_circuit_open: bool,
+    pub events_dropped_total: f64,
+}
+
+/// Source of metrics for the Probe — injectable for testing
+pub trait MetricsSource: Send + Sync {
+    /// Read current metrics. Returns `None` if metrics aren't initialized yet.
+    fn snapshot(&self) -> Option<MetricsSnapshot>;
+}
+
+/// Reads from the global `Metrics::get()` singleton (production default)
+pub struct LiveMetricsSource;
+
+impl MetricsSource for LiveMetricsSource {
+    fn snapshot(&self) -> Option<MetricsSnapshot> {
+        let metrics = Metrics::get()?;
+
+        let (emitter_healthy, emitter_unhealthy) = metrics.emitter_health_counts();
+
+        Some(MetricsSnapshot {
+            pipeline_pressure: metrics.pipeline_pressure.get(),
+            buffer_overflow_total: metrics.buffer_overflow_total.get(),
+            emitter_healthy,
+            emitter_unhealthy,
+            any_circuit_open: any_circuit_open(metrics),
+            events_dropped_total: total_events_dropped(metrics),
+        })
+    }
+}
+
+/// Check if any circuit breaker is in Open state (value >= 1.0)
+fn any_circuit_open(metrics: &Metrics) -> bool {
+    use prometheus::core::Collector;
+
+    let families = metrics.circuit_breaker_state.collect();
+    for family in &families {
+        for metric in family.get_metric() {
+            if metric.get_gauge().get_value() >= 1.0 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Sum all events_dropped counters across all reason labels
+fn total_events_dropped(metrics: &Metrics) -> f64 {
+    use prometheus::core::Collector;
+
+    let families = metrics.events_dropped.collect();
+    let mut total = 0.0;
+    for family in &families {
+        for metric in family.get_metric() {
+            total += metric.get_counter().get_value();
+        }
+    }
+    total
+}
+
+/// Self-aware pipeline observer
+///
+/// Runs as an independent tokio task, reading metrics on a tick interval.
+/// Detects state transitions (edge-triggered) and emits Occurrences via its own Emitter.
+///
+/// # Example
+///
+/// ```ignore
+/// let probe = Probe::new("polku-prod")
+///     .pressure_threshold(0.8)
+///     .tick_secs(5)
+///     .emitter(grpc_ahti);
+/// tokio::spawn(probe.run());
+/// ```
+pub struct Probe {
+    /// Instance name (appears in Occurrence source)
+    instance: String,
+
+    /// Tick interval
+    tick: Duration,
+
+    /// Pipeline pressure threshold (0.0 - 1.0)
+    pressure_threshold: f64,
+
+    /// Emitter for sending Occurrences (side-channel)
+    emitter: Option<Arc<dyn Emitter>>,
+
+    /// Metrics source (injectable for testing)
+    metrics_source: Box<dyn MetricsSource>,
+
+    /// Previous state for edge detection
+    prev: PreviousState,
+}
+
+/// Tracked state from the previous tick (for edge detection)
+#[derive(Default)]
+struct PreviousState {
+    pressure_high: bool,
+    buffer_overflow_total: f64,
+    emitter_unhealthy: bool,
+    circuit_open: bool,
+    events_dropped_total: f64,
+}
+
+impl Probe {
+    pub fn new(instance: &str) -> Self {
+        Self {
+            instance: instance.to_string(),
+            tick: Duration::from_secs(5),
+            pressure_threshold: 0.8,
+            emitter: None,
+            metrics_source: Box::new(LiveMetricsSource),
+            prev: PreviousState::default(),
+        }
+    }
+
+    /// Set the pipeline pressure threshold (default: 0.8)
+    pub fn pressure_threshold(mut self, threshold: f64) -> Self {
+        self.pressure_threshold = threshold;
+        self
+    }
+
+    /// Set the tick interval in seconds (default: 5)
+    pub fn tick_secs(mut self, secs: u64) -> Self {
+        self.tick = Duration::from_secs(secs);
+        self
+    }
+
+    /// Set the Emitter for sending Occurrences
+    pub fn emitter(mut self, emitter: impl Emitter + 'static) -> Self {
+        self.emitter = Some(Arc::new(emitter));
+        self
+    }
+
+    /// Override the metrics source (for testing)
+    pub fn metrics_source(mut self, source: impl MetricsSource + 'static) -> Self {
+        self.metrics_source = Box::new(source);
+        self
+    }
+
+    /// Run the probe loop — call via `tokio::spawn(probe.run())`
+    pub async fn run(mut self) {
+        let Some(emitter) = self.emitter.take() else {
+            tracing::error!("Probe started without an emitter — exiting");
+            return;
+        };
+
+        tracing::info!(
+            instance = %self.instance,
+            tick_ms = self.tick.as_millis() as u64,
+            pressure_threshold = self.pressure_threshold,
+            "probe started"
+        );
+
+        let mut ticker = interval(self.tick);
+
+        loop {
+            ticker.tick().await;
+
+            let Some(snapshot) = self.metrics_source.snapshot() else {
+                tracing::debug!("Metrics not initialized yet, skipping tick");
+                continue;
+            };
+
+            let occurrences = self.evaluate(&snapshot);
+
+            // Emit all collected occurrences
+            if !occurrences.is_empty() {
+                let messages: Vec<Message> = occurrences
+                    .into_iter()
+                    .map(|occ| {
+                        let json = serde_json::to_vec(&occ).unwrap_or_default();
+                        Message::new(
+                            occ.source.as_str(),
+                            occ.occurrence_type.as_str(),
+                            Bytes::from(json),
+                        )
+                    })
+                    .collect();
+
+                if let Err(e) = emitter.emit(&messages).await {
+                    tracing::warn!(error = %e, "probe failed to emit occurrences");
+                }
+            }
+        }
+    }
+
+    /// Evaluate a metrics snapshot and return any triggered Occurrences.
+    ///
+    /// Updates internal edge-detection state. This is the core logic,
+    /// extracted so it can be tested without the async tick loop.
+    fn evaluate(&mut self, snapshot: &MetricsSnapshot) -> Vec<Occurrence> {
+        let mut occurrences = Vec::new();
+
+        // 1. Pipeline pressure
+        let pressure_high = snapshot.pipeline_pressure >= self.pressure_threshold;
+        if pressure_high && !self.prev.pressure_high {
+            occurrences.push(self.build_occurrence(
+                "gateway.pipeline.pressure_high",
+                Severity::Warning,
+                Outcome::InProgress,
+                Some(Error {
+                    code: "PRESSURE_HIGH".into(),
+                    what_failed: format!(
+                        "Pipeline pressure {:.2} exceeds threshold {:.2}",
+                        snapshot.pipeline_pressure, self.pressure_threshold
+                    ),
+                    why_it_matters: Some(
+                        "High pressure indicates the pipeline is approaching overload".into(),
+                    ),
+                    possible_causes: vec![
+                        "Downstream emitters are slow".into(),
+                        "Ingestion rate spike".into(),
+                        "Buffer approaching capacity".into(),
+                    ],
+                    suggested_fix: Some(
+                        "Check emitter health and consider scaling downstream".into(),
+                    ),
+                }),
+                Some(Reasoning {
+                    summary: "Pipeline pressure exceeded threshold".into(),
+                    explanation: format!(
+                        "Composite pressure metric ({:.2}) crossed configured threshold ({:.2}). \
+                         This is a weighted combination of buffer fill, emit failure rate, \
+                         and channel utilization.",
+                        snapshot.pipeline_pressure, self.pressure_threshold
+                    ),
+                    confidence: 0.9,
+                    causal_chain: vec![],
+                    patterns_matched: vec!["threshold_crossing".into()],
+                }),
+            ));
+        }
+        self.prev.pressure_high = pressure_high;
+
+        // 2. Buffer overflow
+        if snapshot.buffer_overflow_total > self.prev.buffer_overflow_total {
+            let delta = snapshot.buffer_overflow_total - self.prev.buffer_overflow_total;
+            occurrences.push(self.build_occurrence(
+                "gateway.buffer.overflow",
+                Severity::Error,
+                Outcome::Failure,
+                Some(Error {
+                    code: "BUFFER_OVERFLOW".into(),
+                    what_failed: format!("{delta:.0} messages dropped due to buffer overflow"),
+                    why_it_matters: Some("Data loss — messages are being discarded".into()),
+                    possible_causes: vec![
+                        "Buffer capacity too small for ingestion rate".into(),
+                        "Emitters not draining fast enough".into(),
+                    ],
+                    suggested_fix: Some("Increase buffer capacity or reduce ingestion rate".into()),
+                }),
+                None,
+            ));
+        }
+        self.prev.buffer_overflow_total = snapshot.buffer_overflow_total;
+
+        // 3. Emitter health
+        let any_unhealthy = snapshot.emitter_unhealthy > 0;
+        if any_unhealthy && !self.prev.emitter_unhealthy {
+            occurrences.push(self.build_occurrence(
+                "gateway.emitter.unhealthy",
+                Severity::Error,
+                Outcome::Failure,
+                Some(Error {
+                    code: "EMITTER_UNHEALTHY".into(),
+                    what_failed: format!(
+                        "{} of {} emitters are unhealthy",
+                        snapshot.emitter_unhealthy,
+                        snapshot.emitter_healthy + snapshot.emitter_unhealthy
+                    ),
+                    why_it_matters: Some("Messages may not reach their destinations".into()),
+                    possible_causes: vec![
+                        "Downstream service is down".into(),
+                        "Network connectivity issues".into(),
+                    ],
+                    suggested_fix: Some("Check downstream service health".into()),
+                }),
+                None,
+            ));
+        }
+        self.prev.emitter_unhealthy = any_unhealthy;
+
+        // 4. Circuit breaker
+        if snapshot.any_circuit_open && !self.prev.circuit_open {
+            occurrences.push(self.build_occurrence(
+                "gateway.emitter.circuit_open",
+                Severity::Critical,
+                Outcome::Failure,
+                Some(Error {
+                    code: "CIRCUIT_OPEN".into(),
+                    what_failed: "Circuit breaker opened for one or more emitters".into(),
+                    why_it_matters: Some(
+                        "Messages to affected emitters are being rejected".into(),
+                    ),
+                    possible_causes: vec![
+                        "Consecutive failures exceeded threshold".into(),
+                        "Downstream service is unresponsive".into(),
+                    ],
+                    suggested_fix: Some(
+                        "Investigate downstream service; circuit will auto-recover via half-open state".into(),
+                    ),
+                }),
+                None,
+            ));
+        }
+        self.prev.circuit_open = snapshot.any_circuit_open;
+
+        // 5. Events dropped (rate increase)
+        if snapshot.events_dropped_total > self.prev.events_dropped_total {
+            let delta = snapshot.events_dropped_total - self.prev.events_dropped_total;
+            occurrences.push(self.build_occurrence(
+                "gateway.events.dropped",
+                Severity::Warning,
+                Outcome::Failure,
+                Some(Error {
+                    code: "EVENTS_DROPPED".into(),
+                    what_failed: format!("{delta:.0} events dropped since last check"),
+                    why_it_matters: Some("Data loss in the pipeline".into()),
+                    possible_causes: vec![
+                        "Buffer overflow".into(),
+                        "Middleware filtering too aggressively".into(),
+                        "Emitter failures".into(),
+                    ],
+                    suggested_fix: None,
+                }),
+                None,
+            ));
+        }
+        self.prev.events_dropped_total = snapshot.events_dropped_total;
+
+        occurrences
+    }
+
+    fn build_occurrence(
+        &self,
+        occurrence_type: &str,
+        severity: Severity,
+        outcome: Outcome,
+        error: Option<Error>,
+        reasoning: Option<Reasoning>,
+    ) -> Occurrence {
+        let id = ulid::Ulid::new().to_string();
+        let timestamp = chrono::Utc::now().to_rfc3339();
+
+        Occurrence {
+            id,
+            timestamp,
+            source: self.instance.clone(),
+            occurrence_type: occurrence_type.to_string(),
+            severity,
+            outcome,
+            context: None,
+            error,
+            reasoning,
+            data: None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use polku_core::PluginError;
+    use std::sync::Mutex;
+
+    // ── Mock MetricsSource ──────────────────────────────────────────────
+
+    struct MockMetricsSource {
+        snapshot: Arc<Mutex<Option<MetricsSnapshot>>>,
+    }
+
+    impl MockMetricsSource {
+        fn new() -> (Self, Arc<Mutex<Option<MetricsSnapshot>>>) {
+            let snapshot = Arc::new(Mutex::new(None));
+            (
+                Self {
+                    snapshot: snapshot.clone(),
+                },
+                snapshot,
+            )
+        }
+    }
+
+    impl MetricsSource for MockMetricsSource {
+        fn snapshot(&self) -> Option<MetricsSnapshot> {
+            let guard = self.snapshot.lock().unwrap();
+            let s = guard.as_ref()?;
+            Some(MetricsSnapshot {
+                pipeline_pressure: s.pipeline_pressure,
+                buffer_overflow_total: s.buffer_overflow_total,
+                emitter_healthy: s.emitter_healthy,
+                emitter_unhealthy: s.emitter_unhealthy,
+                any_circuit_open: s.any_circuit_open,
+                events_dropped_total: s.events_dropped_total,
+            })
+        }
+    }
+
+    fn idle_snapshot() -> MetricsSnapshot {
+        MetricsSnapshot {
+            pipeline_pressure: 0.0,
+            buffer_overflow_total: 0.0,
+            emitter_healthy: 2,
+            emitter_unhealthy: 0,
+            any_circuit_open: false,
+            events_dropped_total: 0.0,
+        }
+    }
+
+    // ── Mock Emitter ────────────────────────────────────────────────────
+
+    struct CapturingEmitter {
+        messages: Arc<Mutex<Vec<Message>>>,
+    }
+
+    impl CapturingEmitter {
+        fn new() -> (Self, Arc<Mutex<Vec<Message>>>) {
+            let messages = Arc::new(Mutex::new(Vec::new()));
+            (
+                Self {
+                    messages: messages.clone(),
+                },
+                messages,
+            )
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Emitter for CapturingEmitter {
+        fn name(&self) -> &str {
+            "capturing"
+        }
+
+        async fn emit(&self, messages: &[Message]) -> Result<(), PluginError> {
+            self.messages
+                .lock()
+                .unwrap()
+                .extend(messages.iter().cloned());
+            Ok(())
+        }
+
+        async fn health(&self) -> bool {
+            true
+        }
+    }
+
+    // ── Unit tests on evaluate() ────────────────────────────────────────
+
+    #[test]
+    fn test_probe_builder() {
+        let (emitter, _) = CapturingEmitter::new();
+        let probe = Probe::new("test-instance")
+            .pressure_threshold(0.9)
+            .tick_secs(10)
+            .emitter(emitter);
+
+        assert_eq!(probe.instance, "test-instance");
+        assert_eq!(probe.pressure_threshold, 0.9);
+        assert_eq!(probe.tick, Duration::from_secs(10));
+        assert!(probe.emitter.is_some());
+    }
+
+    #[test]
+    fn test_pressure_above_threshold_emits() {
+        let mut probe = Probe::new("test");
+
+        let snapshot = MetricsSnapshot {
+            pipeline_pressure: 0.85,
+            ..idle_snapshot()
+        };
+
+        let occs = probe.evaluate(&snapshot);
+        assert_eq!(occs.len(), 1);
+        assert_eq!(occs[0].occurrence_type, "gateway.pipeline.pressure_high");
+        assert_eq!(occs[0].severity, Severity::Warning);
+        assert!(occs[0].error.as_ref().unwrap().what_failed.contains("0.85"));
+    }
+
+    #[test]
+    fn test_pressure_below_threshold_no_emission() {
+        let mut probe = Probe::new("test");
+
+        let snapshot = MetricsSnapshot {
+            pipeline_pressure: 0.5,
+            ..idle_snapshot()
+        };
+
+        let occs = probe.evaluate(&snapshot);
+        assert!(occs.is_empty());
+    }
+
+    #[test]
+    fn test_pressure_edge_triggered_not_level() {
+        let mut probe = Probe::new("test");
+
+        let high = MetricsSnapshot {
+            pipeline_pressure: 0.9,
+            ..idle_snapshot()
+        };
+
+        // First crossing → emit
+        let occs = probe.evaluate(&high);
+        assert_eq!(occs.len(), 1);
+
+        // Still high → no emit (edge-triggered)
+        let occs = probe.evaluate(&high);
+        assert!(occs.is_empty());
+
+        // Back to normal
+        let low = idle_snapshot();
+        let occs = probe.evaluate(&low);
+        assert!(occs.is_empty());
+
+        // Cross again → emit again
+        let occs = probe.evaluate(&high);
+        assert_eq!(occs.len(), 1);
+    }
+
+    #[test]
+    fn test_emitter_unhealthy_emits() {
+        let mut probe = Probe::new("test");
+
+        let snapshot = MetricsSnapshot {
+            emitter_healthy: 1,
+            emitter_unhealthy: 1,
+            ..idle_snapshot()
+        };
+
+        let occs = probe.evaluate(&snapshot);
+        assert_eq!(occs.len(), 1);
+        assert_eq!(occs[0].occurrence_type, "gateway.emitter.unhealthy");
+        assert_eq!(occs[0].severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_emitter_unhealthy_edge_triggered() {
+        let mut probe = Probe::new("test");
+
+        let unhealthy = MetricsSnapshot {
+            emitter_unhealthy: 1,
+            ..idle_snapshot()
+        };
+
+        // First → emit
+        assert_eq!(probe.evaluate(&unhealthy).len(), 1);
+        // Still unhealthy → no emit
+        assert!(probe.evaluate(&unhealthy).is_empty());
+        // Recovered
+        assert!(probe.evaluate(&idle_snapshot()).is_empty());
+        // Unhealthy again → emit
+        assert_eq!(probe.evaluate(&unhealthy).len(), 1);
+    }
+
+    #[test]
+    fn test_buffer_overflow_emits_on_increase() {
+        let mut probe = Probe::new("test");
+
+        let snapshot = MetricsSnapshot {
+            buffer_overflow_total: 5.0,
+            ..idle_snapshot()
+        };
+
+        let occs = probe.evaluate(&snapshot);
+        assert_eq!(occs.len(), 1);
+        assert_eq!(occs[0].occurrence_type, "gateway.buffer.overflow");
+        assert!(occs[0].error.as_ref().unwrap().what_failed.contains("5"));
+
+        // Same total → no emit
+        assert!(probe.evaluate(&snapshot).is_empty());
+
+        // More overflow → emit again
+        let more = MetricsSnapshot {
+            buffer_overflow_total: 12.0,
+            ..idle_snapshot()
+        };
+        let occs = probe.evaluate(&more);
+        assert_eq!(occs.len(), 1);
+        assert!(occs[0].error.as_ref().unwrap().what_failed.contains("7"));
+    }
+
+    #[test]
+    fn test_circuit_open_emits() {
+        let mut probe = Probe::new("test");
+
+        let snapshot = MetricsSnapshot {
+            any_circuit_open: true,
+            ..idle_snapshot()
+        };
+
+        let occs = probe.evaluate(&snapshot);
+        assert_eq!(occs.len(), 1);
+        assert_eq!(occs[0].occurrence_type, "gateway.emitter.circuit_open");
+        assert_eq!(occs[0].severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_events_dropped_emits_on_increase() {
+        let mut probe = Probe::new("test");
+
+        let snapshot = MetricsSnapshot {
+            events_dropped_total: 10.0,
+            ..idle_snapshot()
+        };
+
+        let occs = probe.evaluate(&snapshot);
+        assert_eq!(occs.len(), 1);
+        assert_eq!(occs[0].occurrence_type, "gateway.events.dropped");
+    }
+
+    #[test]
+    fn test_multiple_conditions_emit_multiple_occurrences() {
+        let mut probe = Probe::new("test");
+
+        let snapshot = MetricsSnapshot {
+            pipeline_pressure: 0.95,
+            buffer_overflow_total: 3.0,
+            emitter_healthy: 0,
+            emitter_unhealthy: 2,
+            any_circuit_open: true,
+            events_dropped_total: 50.0,
+        };
+
+        let occs = probe.evaluate(&snapshot);
+        assert_eq!(occs.len(), 5);
+
+        let types: Vec<&str> = occs.iter().map(|o| o.occurrence_type.as_str()).collect();
+        assert!(types.contains(&"gateway.pipeline.pressure_high"));
+        assert!(types.contains(&"gateway.buffer.overflow"));
+        assert!(types.contains(&"gateway.emitter.unhealthy"));
+        assert!(types.contains(&"gateway.emitter.circuit_open"));
+        assert!(types.contains(&"gateway.events.dropped"));
+    }
+
+    #[test]
+    fn test_idle_system_no_emissions() {
+        let mut probe = Probe::new("test");
+        let occs = probe.evaluate(&idle_snapshot());
+        assert!(occs.is_empty());
+    }
+
+    // ── Async integration test with mock ────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn test_probe_tick_emits_via_emitter() {
+        let (mock_source, mock_state) = MockMetricsSource::new();
+        let (emitter, captured) = CapturingEmitter::new();
+
+        let probe = Probe::new("test-prod")
+            .tick_secs(1)
+            .pressure_threshold(0.8)
+            .metrics_source(mock_source)
+            .emitter(emitter);
+
+        let handle = tokio::spawn(probe.run());
+
+        // Tick 1: no metrics → skip
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert!(captured.lock().unwrap().is_empty());
+
+        // Set metrics: pressure high
+        *mock_state.lock().unwrap() = Some(MetricsSnapshot {
+            pipeline_pressure: 0.9,
+            buffer_overflow_total: 0.0,
+            emitter_healthy: 2,
+            emitter_unhealthy: 0,
+            any_circuit_open: false,
+            events_dropped_total: 0.0,
+        });
+
+        // Tick 2: pressure high → emit
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        // Give the spawned task a chance to process
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        let msgs = captured.lock().unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message_type, "gateway.pipeline.pressure_high");
+
+        handle.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_probe_tick_interval_respected() {
+        let (mock_source, mock_state) = MockMetricsSource::new();
+        let (emitter, captured) = CapturingEmitter::new();
+
+        let probe = Probe::new("test")
+            .tick_secs(5)
+            .metrics_source(mock_source)
+            .emitter(emitter);
+
+        let handle = tokio::spawn(probe.run());
+
+        // interval fires immediately at t=0 — let first tick pass (no metrics yet)
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert!(captured.lock().unwrap().is_empty());
+
+        // Set metrics with unhealthy emitter
+        *mock_state.lock().unwrap() = Some(MetricsSnapshot {
+            pipeline_pressure: 0.0,
+            buffer_overflow_total: 0.0,
+            emitter_healthy: 0,
+            emitter_unhealthy: 1,
+            any_circuit_open: false,
+            events_dropped_total: 0.0,
+        });
+
+        // Advance 3s (less than 5s tick) → no emission yet
+        tokio::time::advance(Duration::from_secs(3)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert!(captured.lock().unwrap().is_empty());
+
+        // Advance 2 more seconds (total 5s) → tick fires, emits
+        tokio::time::advance(Duration::from_secs(2)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(captured.lock().unwrap().len(), 1);
+
+        handle.abort();
+    }
+}


### PR DESCRIPTION
## Summary

- **`polku-fp`** — new crate with FALSE Protocol plugins for POLKU
- **`OccurrenceIngestor`** — decodes Occurrence JSON into Messages, preserves full JSON in payload
- **`OccurrenceRouter`** — routes by `message_type` prefix (e.g. `"ci."` → sykli, `"kernel."` → tapio)
- **`Probe`** — standalone async observer that reads `Metrics` singleton, detects state transitions (edge-triggered), and emits Occurrences via its own Emitter side-channel

Zero changes to `core/` or `gateway/`. Three capabilities, all opt-in:
- **Transport**: wire up `OccurrenceIngestor` + `OccurrenceRouter`
- **Self-aware**: spawn a `Probe`
- **Clean**: don't import `polku-fp`

## Test plan

- [x] 31 unit + DST tests covering all components
- [x] OccurrenceIngestor: field mapping, error blocks, invalid JSON, arrays, payload preservation
- [x] OccurrenceRouter: prefix routing, first-match-wins, multi-target, passthrough
- [x] Probe: edge-triggered emission for all 5 conditions, mock `MetricsSource` for DST
- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test --all-targets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)